### PR TITLE
del  “ tail -f -n 0 "${LOG_FILE}"  “ in run.sh

### DIFF
--- a/plink-dist/src/main/plink-bin/bin/run.sh
+++ b/plink-dist/src/main/plink-bin/bin/run.sh
@@ -34,7 +34,6 @@ case "$1" in
         touch "$LOG_FILE"
         exec java -jar "$JARFILE" "$profile" --spring.config.location=$SERVER_ROOT_PATH/config/ >> "${LOG_FILE}" 2>&1 &
         echo "server starting log to " "${LOG_FILE}"
-        tail -f -n 0 "${LOG_FILE}"
     ;;
 
     *)


### PR DESCRIPTION
在一个窗口通过 ./bin/run.sh start local启动web以后，关闭此窗口后plink-web进程不存在了，删除tail -f -n 0 "${LOG_FILE}" 以后可修复次问题