### PR TITLE
HADOOP_CONF_DIR is better

### DIFF
--- a/plink-common/src/main/java/com/github/hairless/plink/common/util/HadoopConfigUtil.java
+++ b/plink-common/src/main/java/com/github/hairless/plink/common/util/HadoopConfigUtil.java
@@ -19,9 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @date: 2020/9/04
  */
 public class HadoopConfigUtil {
-    private static final String CONF_SUFFIX = "/etc/hadoop";
     private static final Map<String, Configuration> configurationMap = new ConcurrentHashMap<>();
-
 
     public static String getHadoopHome() throws PlinkException {
         String hadoopHome = System.getenv("HADOOP_HOME");
@@ -31,29 +29,37 @@ public class HadoopConfigUtil {
         return hadoopHome;
     }
 
-    private static synchronized void loadConfiguration(String hadoopHome) {
-        if (!configurationMap.containsKey(hadoopHome)) {
-            Preconditions.checkArgument(StringUtils.isNotBlank(hadoopHome), "hadoopHome is empty");
-            Collection<File> files = FileUtils.listFiles(new File(hadoopHome, CONF_SUFFIX), new String[]{"xml"}, false);
+    public static String getHadoopConfDir() throws PlinkException {
+        String hadoopHome = System.getenv("HADOOP_CONF_DIR");
+        if (StringUtils.isBlank(hadoopHome)) {
+            throw new PlinkException("HADOOP_HOME is not set!");
+        }
+        return hadoopHome;
+    }
+
+    private static synchronized void loadConfiguration(String hadoopConfDir) {
+        if (!configurationMap.containsKey(hadoopConfDir)) {
+            Preconditions.checkArgument(StringUtils.isNotBlank(hadoopConfDir), "hadoopConfDir is empty");
+            Collection<File> files = FileUtils.listFiles(new File(hadoopConfDir), new String[]{"xml"}, false);
             Configuration conf = new Configuration();
             if (CollectionUtils.isNotEmpty(files)) {
                 for (File file : files) {
                     conf.addResource(new Path(file.getAbsolutePath()));
                 }
             }
-            configurationMap.put(hadoopHome, conf);
+            configurationMap.put(hadoopConfDir, conf);
         }
     }
 
     public static synchronized Configuration getConfiguration() throws PlinkException {
-        return getConfiguration(getHadoopHome());
+        return getConfiguration(getHadoopConfDir());
     }
 
-    public static synchronized Configuration getConfiguration(String hadoopHome) throws PlinkException {
-        if (!configurationMap.containsKey(hadoopHome)) {
-            loadConfiguration(hadoopHome);
+    public static synchronized Configuration getConfiguration(String hadoopConfDir) throws PlinkException {
+        if (!configurationMap.containsKey(hadoopConfDir)) {
+            loadConfiguration(hadoopConfDir);
         }
-        return configurationMap.get(hadoopHome);
+        return configurationMap.get(hadoopConfDir);
     }
 
 }

--- a/plink-rpc/src/main/java/com/github/hairless/plink/rpc/impl/YarnClientRpcServiceImpl.java
+++ b/plink-rpc/src/main/java/com/github/hairless/plink/rpc/impl/YarnClientRpcServiceImpl.java
@@ -47,7 +47,7 @@ public class YarnClientRpcServiceImpl implements YarnClientRpcService {
 
     @Override
     public YarnApplicationState getYarnApplicationState(String appId) throws PlinkException {
-        return getYarnApplicationState(HadoopConfigUtil.getHadoopHome(), appId);
+        return getYarnApplicationState(HadoopConfigUtil.getHadoopConfDir(), appId);
     }
 
     @Override


### PR DESCRIPTION
@sllence 您好，我在部署项目的时候，因为公司用的是Cloudera的发行版，没有HADOOP_HOME路径，yarn配置在HADOOP_CONF_DIR，例如/etc/hadoop/conf内，不在HADOOP_HOME/etc/conf下，**代码强制指定了后缀为`/etc/hadoop/`，如果是这样就指向了错误的位置**。这个PR将HADOOP_HOME换成HADOOP_CONF_DIR，因为这里仅读取yarn-site.xml等配置文件，这种方式更为直接和一般化。